### PR TITLE
Harden CLI argument handling and scaffold templates

### DIFF
--- a/command.go
+++ b/command.go
@@ -51,16 +51,16 @@ func (c *Command) Init() string {
 // It requires two arguments: content type and filename.
 // The content type defines the path, so it can also include a subfolder
 func (c *Command) New(config Config) {
-	if len(os.Args) < 4 {
+	if len(c.Args) < 3 {
 		logger.Warn("Missing arguments. Usage: repose new [CONTENTTYPE] [FILENAME]")
 		return
-	} else if len(os.Args) > 4 {
+	} else if len(c.Args) > 3 {
 		logger.Warn("File name cannot contain spaces. Usage: repose new [CONTENTTYPE] [FILENAME]")
 		return
 	}
 
-	typeDirectory := os.Args[2]
-	fileNameParam := os.Args[3]
+	typeDirectory := c.Args[1]
+	fileNameParam := c.Args[2]
 
 	if err := c.createNewContent(config, typeDirectory, fileNameParam); err != nil {
 		logger.Error(err.Error())

--- a/commandBuild.go
+++ b/commandBuild.go
@@ -12,6 +12,8 @@ import (
 	"github.com/yuin/goldmark"
 	meta "github.com/yuin/goldmark-meta"
 	"github.com/yuin/goldmark/parser"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Controls the build command
@@ -26,6 +28,11 @@ type Builder struct {
 
 // Defining a global varaiable for build command
 var buildCommand Builder
+
+var (
+	titleCaser    = cases.Title(language.English)
+	titleReplacer = strings.NewReplacer("-", " ", "_", " ")
+)
 
 // Holds information about a directory during processing
 // Keyed by the full path to the directory
@@ -291,10 +298,40 @@ func (b *Builder) processMarkdown(filePath string) (htmlContent string, metaData
 // Render the HTML content with the template and write to the output directory
 func (b *Builder) renderAndWriteFile(outputPath string, file FileInfo) error {
 	// Extract the template name from outputPath or set a default
-	templateFile := file.MetaData["template"].(string)
-	if templateFile == "" {
-		templateFile = "default.tmpl"
+	templateFile := "default.tmpl"
+	if file.MetaData == nil {
+		file.MetaData = make(map[string]interface{})
 	}
+
+	if rawTemplate, exists := file.MetaData["template"]; exists {
+		if tmpl, ok := rawTemplate.(string); ok {
+			tmpl = strings.TrimSpace(tmpl)
+			if tmpl != "" {
+				templateFile = tmpl
+			} else {
+				logger.Warn("Template metadata for %s is empty; using default.tmpl", file.Path)
+			}
+		} else {
+			logger.Warn("Template metadata for %s must be a string; using default.tmpl", file.Path)
+		}
+	}
+
+	file.MetaData["template"] = templateFile
+
+	title := deriveTitle(file)
+	if rawTitle, exists := file.MetaData["title"]; exists {
+		if titleStr, ok := rawTitle.(string); ok {
+			cleanedTitle := strings.TrimSpace(titleStr)
+			if cleanedTitle != "" {
+				title = cleanedTitle
+			} else {
+				logger.Warn("Title metadata for %s is empty; deriving from filename", file.Path)
+			}
+		} else {
+			logger.Warn("Title metadata for %s must be a string; deriving from filename", file.Path)
+		}
+	}
+	file.MetaData["title"] = title
 
 	// Process the MD content with the template
 	// This will be used to process the full page from the template
@@ -307,7 +344,7 @@ func (b *Builder) renderAndWriteFile(outputPath string, file FileInfo) error {
 	pageData := PageData{
 		SiteName: config.Sitename,
 		Logo:     logo50,
-		Title:    file.MetaData["title"].(string),
+		Title:    title,
 		Content:  template.HTML(templateContent),
 		Metadata: file.MetaData,
 	}
@@ -383,6 +420,21 @@ func (b *Builder) getTemplateContent(file FileInfo, templateFile string) (templa
 	}
 
 	return template.HTML(tmplContent.String()), nil
+}
+
+func deriveTitle(file FileInfo) string {
+	cleaned := strings.TrimSpace(file.Name)
+	if cleaned == "" {
+		return "Untitled"
+	}
+
+	cleaned = titleReplacer.Replace(cleaned)
+	cleaned = strings.Join(strings.Fields(cleaned), " ")
+	if cleaned == "" {
+		return "Untitled"
+	}
+
+	return titleCaser.String(cleaned)
 }
 
 // Parse the templates and store them in a global variable

--- a/commandInit.go
+++ b/commandInit.go
@@ -83,6 +83,7 @@ func (i *Init) getTemplateContents(config Config) []FileContent {
 			"navigation": NavigationTemplate_pico,
 			"footer":     FooterTemplate_pico,
 			"list":       ListTemplate_pico,
+			"listitem":   ListItemTemplate_pico,
 			"css":        css_pico,
 		},
 		"bootstrap": {
@@ -92,6 +93,7 @@ func (i *Init) getTemplateContents(config Config) []FileContent {
 			"navigation": NavigationTemplate_bootstrap,
 			"footer":     FooterTemplate_bootstrap,
 			"list":       ListTemplate_bootstrap,
+			"listitem":   ListItemTemplate_bootstrap,
 			"css":        css_bootstrap,
 		},
 		"tailwind": {
@@ -101,6 +103,7 @@ func (i *Init) getTemplateContents(config Config) []FileContent {
 			"navigation": NavigationTemplate_tailwind,
 			"footer":     FooterTemplate_tailwind,
 			"list":       ListTemplate_tailwind,
+			"listitem":   ListItemTemplate_tailwind,
 			"css":        css_tailwind,
 		},
 		"none": {
@@ -110,6 +113,7 @@ func (i *Init) getTemplateContents(config Config) []FileContent {
 			"navigation": NavigationTemplate_none,
 			"footer":     FooterTemplate_none,
 			"list":       ListTemplate_none,
+			"listitem":   ListItemTemplate_none,
 			"css":        css_none,
 		},
 	}
@@ -128,7 +132,7 @@ func (i *Init) getTemplateContents(config Config) []FileContent {
 		{"template/listitem.tmpl", themeTemplates["listitem"]},
 		{"content/index.md", indexMD},
 		{"content/test.md", MarkdownTest},
-		{"web/asset/css/styles.css", themeTemplates["css"]},
+		{"web/assets/css/styles.css", themeTemplates["css"]},
 	}
 
 	return files

--- a/defaultTemplates.go
+++ b/defaultTemplates.go
@@ -10,7 +10,7 @@ const ListTemplate_none = `<!-- list.tmpl -->
 <article>
     <ul>
     {{ range .Files }}
-    <li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
+        {{ template "listitem.tmpl" . }}
     {{ end }}
     </ul>
 </article>
@@ -23,7 +23,7 @@ const PageTemplate_none = `<!-- fullpage.tmpl -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/asset/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 <body>
     {{ template "header.tmpl" . }}
@@ -34,6 +34,10 @@ const PageTemplate_none = `<!-- fullpage.tmpl -->
     {{ template "footer.tmpl" . }}
 </body>
 </html>
+`
+
+const ListItemTemplate_none = `<!-- listitem.tmpl -->
+<li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
 `
 
 const HeaderTemplate_none = `<!-- header.tmpl -->

--- a/defaultTemplates_bootstrap.go
+++ b/defaultTemplates_bootstrap.go
@@ -10,7 +10,7 @@ const ListTemplate_bootstrap = `<!-- list.tmpl -->
 <article>
     <ul>
     {{ range .Files }}
-    <li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
+        {{ template "listitem.tmpl" . }}
     {{ end }}
     </ul>
 </article>
@@ -25,7 +25,7 @@ const PageTemplate_bootstrap = `<!-- fullpage.tmpl -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/asset/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 <body>
     {{ template "header.tmpl" . }}
@@ -35,6 +35,10 @@ const PageTemplate_bootstrap = `<!-- fullpage.tmpl -->
     {{ template "footer.tmpl" . }}
 </body>
 </html>
+`
+
+const ListItemTemplate_bootstrap = `<!-- listitem.tmpl -->
+<li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
 `
 
 const HeaderTemplate_bootstrap = `<!-- header.tmpl -->

--- a/defaultTemplates_pico.go
+++ b/defaultTemplates_pico.go
@@ -10,7 +10,7 @@ const ListTemplate_pico = `<!-- list.tmpl -->
 <article>
     <ul>
     {{ range .Files }}
-    <li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
+        {{ template "listitem.tmpl" . }}
     {{ end }}
     </ul>
 </article>
@@ -24,7 +24,7 @@ const PageTemplate_pico = `<!-- fullpage.tmpl -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ .Title }}</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css">
-    <link rel="stylesheet" href="/asset/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 <body>
     {{ template "header.tmpl" . }}
@@ -34,6 +34,10 @@ const PageTemplate_pico = `<!-- fullpage.tmpl -->
     {{ template "footer.tmpl" . }}
 </body>
 </html>
+`
+
+const ListItemTemplate_pico = `<!-- listitem.tmpl -->
+<li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
 `
 
 const HeaderTemplate_pico = `<!-- header.tmpl -->

--- a/defaultTemplates_tailwind.go
+++ b/defaultTemplates_tailwind.go
@@ -10,7 +10,7 @@ const ListTemplate_tailwind = `<!-- list.tmpl -->
 <article>
     <ul>
     {{ range .Files }}
-    <li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
+        {{ template "listitem.tmpl" . }}
     {{ end }}
     </ul>
 </article>
@@ -24,7 +24,7 @@ const PageTemplate_tailwind = `<!-- fullpage.tmpl -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com"></script>
     <title>{{ .Title }}</title>
-    <link rel="stylesheet" href="/asset/css/styles.css">
+    <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 <body>
     {{ template "header.tmpl" . }}
@@ -35,6 +35,10 @@ const PageTemplate_tailwind = `<!-- fullpage.tmpl -->
     {{ template "footer.tmpl" . }}
 </body>
 </html>
+`
+
+const ListItemTemplate_tailwind = `<!-- listitem.tmpl -->
+<li><a href="{{ .OutputPath }}">{{ .MetaData.title }}</a></li>
 `
 
 const HeaderTemplate_tailwind = `<!-- header.tmpl -->


### PR DESCRIPTION
## Summary
- use the parsed command arguments when creating new content so CLI flags are honored
- guard template and title metadata during site builds and derive safe fallbacks
- add the missing list-item templates for each theme and fix the generated assets path

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d6f8d89c60832e90f8837a91dc07bb