### PR TITLE
Add unit tests for filesystem and command helpers

### DIFF
--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandProcessFileName(t *testing.T) {
+	var c Command
+
+	fileName, title := c.processFileName("my-first-post")
+	if fileName != "my-first-post.md" {
+		t.Fatalf("expected markdown extension, got %s", fileName)
+	}
+	if title != "My First Post" {
+		t.Fatalf("unexpected title: %s", title)
+	}
+
+	fileName, title = c.processFileName("already.html")
+	if fileName != "already.html" {
+		t.Fatalf("expected filename to remain unchanged, got %s", fileName)
+	}
+	if title != "Already" {
+		t.Fatalf("unexpected title for html file: %s", title)
+	}
+}
+
+func TestCommandDefaultContent(t *testing.T) {
+	originalConfig := config
+	config = Config{Author: "Test Author"}
+	t.Cleanup(func() { config = originalConfig })
+
+	var c Command
+	content := c.defaultContent("post", "My Great Post")
+
+	if !strings.Contains(content, "title: My Great Post") {
+		t.Fatalf("expected title to be inserted into content: %s", content)
+	}
+	if !strings.Contains(content, "description: post about My Great Post") {
+		t.Fatalf("expected description to include content type and title: %s", content)
+	}
+	if !strings.Contains(content, "author: Test Author") {
+		t.Fatalf("expected author to be pulled from config: %s", content)
+	}
+	if !strings.Contains(content, "template: post.tmpl") {
+		t.Fatalf("expected template name to be based on content type: %s", content)
+	}
+}
+
+func TestCommandCreateNewContent(t *testing.T) {
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+
+	tempRoot := t.TempDir()
+	if err := os.Chdir(tempRoot); err != nil {
+		t.Fatalf("failed to change working directory: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(originalWD)
+	})
+
+	if err := os.MkdirAll("template", 0o755); err != nil {
+		t.Fatalf("failed to create template directory: %v", err)
+	}
+
+	originalConfig := config
+	config = Config{Author: "Author", ContentDirectory: "content"}
+	t.Cleanup(func() { config = originalConfig })
+
+	cfg := config
+
+	var c Command
+	if err := c.createNewContent(cfg, "posts", "new-entry"); err != nil {
+		t.Fatalf("createNewContent returned error: %v", err)
+	}
+
+	expectedPath := filepath.Join("content", "posts", "new-entry.md")
+	data, err := os.ReadFile(expectedPath)
+	if err != nil {
+		t.Fatalf("expected file to be created at %s: %v", expectedPath, err)
+	}
+
+	if !strings.Contains(string(data), "title: New Entry") {
+		t.Fatalf("expected generated file to contain formatted title, got: %s", string(data))
+	}
+	if !strings.Contains(string(data), "author: Author") {
+		t.Fatalf("expected generated file to contain author from config, got: %s", string(data))
+	}
+}
+
+func TestConfigLoad(t *testing.T) {
+	tempRoot := t.TempDir()
+	configContent := "sitename: Example\nauthor: Alice\neditor: vim\ncontentDirectory: content\noutputDirectory: public\nurl: https://example.com\npreviewUrl: http://localhost:9000\ntheme: pico\n"
+
+	configPath := filepath.Join(tempRoot, ConfigFile)
+	if err := os.WriteFile(configPath, []byte(configContent), 0o644); err != nil {
+		t.Fatalf("failed to write config file: %v", err)
+	}
+
+	originalRoot := buildCommand.rootPath
+	buildCommand.rootPath = tempRoot
+	t.Cleanup(func() { buildCommand.rootPath = originalRoot })
+
+	var cfg Config
+	loaded, err := cfg.Load()
+	if err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if loaded.Sitename != "Example" {
+		t.Fatalf("expected sitename Example, got %s", loaded.Sitename)
+	}
+	if loaded.Author != "Alice" {
+		t.Fatalf("expected author Alice, got %s", loaded.Author)
+	}
+	if loaded.Editor != "vim" {
+		t.Fatalf("expected editor vim, got %s", loaded.Editor)
+	}
+	if loaded.ContentDirectory != "content" {
+		t.Fatalf("expected content directory content, got %s", loaded.ContentDirectory)
+	}
+	if loaded.OutputDirectory != "public" {
+		t.Fatalf("expected output directory public, got %s", loaded.OutputDirectory)
+	}
+	if loaded.URL != "https://example.com" {
+		t.Fatalf("expected URL https://example.com, got %s", loaded.URL)
+	}
+	if loaded.PreviewURL != "http://localhost:9000" {
+		t.Fatalf("expected preview URL http://localhost:9000, got %s", loaded.PreviewURL)
+	}
+	if loaded.Theme != "pico" {
+		t.Fatalf("expected theme pico, got %s", loaded.Theme)
+	}
+}

--- a/filesystem_test.go
+++ b/filesystem_test.go
@@ -3,65 +3,269 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
-func TestFilesystem_Create(t *testing.T) {
-	// Define test directory and file
-	testDir := "./testdir"
-	testFile := filepath.Join(testDir, "testfile.txt")
-	testContent := "Hello, Filesystem!"
+func relPath(t *testing.T, target string) string {
+	t.Helper()
 
-	// Test creating a directory
-	err := filesystem.Create(testDir, "")
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Errorf("Failed to create directory: %s", err)
+		t.Fatalf("failed to get working directory: %v", err)
 	}
 
-	// Test creating a file
-	err = filesystem.Create(testFile, testContent)
+	rel, err := filepath.Rel(cwd, target)
 	if err != nil {
-		t.Errorf("Failed to create file: %s", err)
+		t.Fatalf("failed to compute relative path: %v", err)
 	}
 
-	// Check if file content is correct
-	content, _ := os.ReadFile(testFile)
-	if string(content) != testContent {
-		t.Errorf("File content mismatch. Got: %s, Want: %s", string(content), testContent)
-	}
-
-	// Cleanup
-	os.RemoveAll(testDir)
+	return rel
 }
 
-func TestFilesystem_Delete(t *testing.T) {
-	// Define test directory and file
-	testDir := "./testdir"
-	testFile := filepath.Join(testDir, "testfile.txt")
+func TestFilesystemExists(t *testing.T) {
+	tempDir := t.TempDir()
+	existingFile := filepath.Join(tempDir, "exists.txt")
+	if err := os.WriteFile(existingFile, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
 
-	// Create a directory and a file to test deletion
-	os.MkdirAll(testDir, 0755)
-	os.WriteFile(testFile, []byte("test content"), 0644)
+	if !filesystem.Exists(existingFile) {
+		t.Fatalf("expected file %s to exist", existingFile)
+	}
 
-	// Test deleting the file
-	err := filesystem.Delete(testFile)
+	missingFile := filepath.Join(tempDir, "missing.txt")
+	if filesystem.Exists(missingFile) {
+		t.Fatalf("expected file %s to be missing", missingFile)
+	}
+}
+
+func TestFilesystemExistsRecursive(t *testing.T) {
+	tempDir := t.TempDir()
+	nestedDir := filepath.Join(tempDir, "a", "b")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested directory: %v", err)
+	}
+
+	targetFile := filepath.Join(nestedDir, "target.txt")
+	if err := os.WriteFile(targetFile, []byte("hello"), 0o644); err != nil {
+		t.Fatalf("failed to write target file: %v", err)
+	}
+
+	exists, err := filesystem.ExistsRecursive("target.txt", tempDir)
 	if err != nil {
-		t.Errorf("Failed to delete file: %s", err)
+		t.Fatalf("unexpected error searching for existing file: %v", err)
+	}
+	if !exists {
+		t.Fatalf("expected target file to be found recursively")
 	}
 
-	// Check if file is deleted
-	if _, err := os.Stat(testFile); !os.IsNotExist(err) {
-		t.Errorf("File still exists after deletion")
-	}
-
-	// Test deleting the directory
-	err = filesystem.Delete(testDir)
+	exists, err = filesystem.ExistsRecursive("missing.txt", tempDir)
 	if err != nil {
-		t.Errorf("Failed to delete directory: %s", err)
+		t.Fatalf("unexpected error searching for missing file: %v", err)
+	}
+	if exists {
+		t.Fatalf("did not expect missing file to be reported as existing")
 	}
 
-	// Check if directory is deleted
-	if _, err := os.Stat(testDir); !os.IsNotExist(err) {
-		t.Errorf("Directory still exists after deletion")
+	_, err = filesystem.ExistsRecursive("whatever.txt", filepath.Join(tempDir, "does-not-exist"))
+	if err == nil {
+		t.Fatalf("expected an error when walking a directory that does not exist")
+	}
+}
+
+func TestFilesystemCreate(t *testing.T) {
+	tempDir := t.TempDir()
+
+	filePath := filepath.Join(tempDir, "nested", "file.txt")
+	if err := filesystem.Create(filePath, "Hello, Filesystem!"); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("failed to read created file: %v", err)
+	}
+	if string(data) != "Hello, Filesystem!" {
+		t.Fatalf("unexpected file contents: %s", string(data))
+	}
+
+	dirPath := filepath.Join(tempDir, "anotherDir")
+	if err := filesystem.Create(dirPath, ""); err != nil {
+		t.Fatalf("failed to create directory: %v", err)
+	}
+	if info, err := os.Stat(dirPath); err != nil || !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", dirPath)
+	}
+
+	if err := filesystem.Create(filePath, "new content"); err == nil {
+		t.Fatalf("expected error when attempting to recreate existing file")
+	}
+}
+
+func TestFilesystemRead(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "readme.txt")
+
+	if err := os.WriteFile(filePath, []byte("Read me"), 0o644); err != nil {
+		t.Fatalf("failed to write file for reading: %v", err)
+	}
+
+	content, err := filesystem.Read(filePath)
+	if err != nil {
+		t.Fatalf("failed to read existing file: %v", err)
+	}
+	if content != "Read me" {
+		t.Fatalf("unexpected content from Read: %s", content)
+	}
+
+	_, err = filesystem.Read(filepath.Join(tempDir, "missing.txt"))
+	if err == nil {
+		t.Fatalf("expected error when reading missing file")
+	}
+}
+
+func TestFilesystemDelete(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "deleteme.txt")
+
+	if err := os.WriteFile(filePath, []byte("delete"), 0o644); err != nil {
+		t.Fatalf("failed to write file for deletion: %v", err)
+	}
+
+	if err := filesystem.Delete(filePath); err != nil {
+		t.Fatalf("failed to delete existing file: %v", err)
+	}
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Fatalf("expected file to be deleted")
+	}
+
+	if err := filesystem.Delete(filepath.Join(tempDir, "missing.txt")); err == nil {
+		t.Fatalf("expected error when deleting a missing file")
+	}
+}
+
+func TestFilesystemIsDir(t *testing.T) {
+	tempDir := t.TempDir()
+	dirRel := relPath(t, tempDir)
+
+	isDir, err := filesystem.IsDir(dirRel)
+	if err != nil {
+		t.Fatalf("unexpected error checking directory: %v", err)
+	}
+	if !isDir {
+		t.Fatalf("expected %s to be a directory", dirRel)
+	}
+
+	filePath := filepath.Join(tempDir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	fileRel := relPath(t, filePath)
+
+	isDir, err = filesystem.IsDir(fileRel)
+	if err != nil {
+		t.Fatalf("unexpected error checking file: %v", err)
+	}
+	if isDir {
+		t.Fatalf("expected %s to be reported as a file", fileRel)
+	}
+
+	_, err = filesystem.IsDir(filepath.Join(dirRel, "missing"))
+	if err == nil {
+		t.Fatalf("expected error when checking a path that does not exist")
+	}
+}
+
+func TestFilesystemParseYml(t *testing.T) {
+	content := "sitename: Example\nurl: https://example.com\n"
+
+	result, err := filesystem.ParseYml(content)
+	if err != nil {
+		t.Fatalf("unexpected error parsing valid yaml: %v", err)
+	}
+
+	if result["sitename"] != "Example" {
+		t.Fatalf("expected sitename to be parsed, got %s", result["sitename"])
+	}
+	if result["url"] != "https://example.com" {
+		t.Fatalf("expected url to be parsed, got %s", result["url"])
+	}
+
+	if _, err := filesystem.ParseYml(""); err == nil {
+		t.Fatalf("expected error when parsing empty yaml")
+	}
+
+	if _, err := filesystem.ParseYml("invalid-line-without-colon"); err == nil {
+		t.Fatalf("expected error when parsing invalid yaml content")
+	}
+}
+
+func TestFilesystemGetFileInfo(t *testing.T) {
+	tempDir := t.TempDir()
+	contentDir := filepath.Join(tempDir, "content")
+	if err := os.MkdirAll(filepath.Join(contentDir, "blog"), 0o755); err != nil {
+		t.Fatalf("failed to create content directory: %v", err)
+	}
+
+	filePath := filepath.Join(contentDir, "blog", "post.md")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to write content file: %v", err)
+	}
+
+	rootRel := relPath(t, contentDir)
+	fileRel := relPath(t, filePath)
+
+	relPathResult, dir, firstSubdir, fileName, extension, err := filesystem.GetFileInfo(rootRel, fileRel)
+	if err != nil {
+		t.Fatalf("unexpected error getting file info: %v", err)
+	}
+
+	expectedRel := filepath.Join("blog", "post.md")
+	if relPathResult != expectedRel {
+		t.Fatalf("expected relative path %s, got %s", expectedRel, relPathResult)
+	}
+	if dir != "blog" {
+		t.Fatalf("expected directory 'blog', got %s", dir)
+	}
+	if firstSubdir != "blog" {
+		t.Fatalf("expected first subdir 'blog', got %s", firstSubdir)
+	}
+	if fileName != "post" {
+		t.Fatalf("expected file name 'post', got %s", fileName)
+	}
+	if extension != "md" {
+		t.Fatalf("expected extension 'md', got %s", extension)
+	}
+}
+
+func TestFilesystemGetFileInfoErrors(t *testing.T) {
+	tempDir := t.TempDir()
+	contentDir := filepath.Join(tempDir, "content")
+	if err := os.MkdirAll(contentDir, 0o755); err != nil {
+		t.Fatalf("failed to create content directory: %v", err)
+	}
+
+	rootRel := relPath(t, contentDir)
+
+	_, _, _, _, _, err := filesystem.GetFileInfo(rootRel, filepath.Join(rootRel, "missing.md"))
+	if err == nil || !strings.Contains(err.Error(), "path does not exist") {
+		t.Fatalf("expected missing path error, got %v", err)
+	}
+
+	_, _, _, _, _, err = filesystem.GetFileInfo(rootRel, rootRel)
+	if err == nil || !strings.Contains(err.Error(), "path is a directory") {
+		t.Fatalf("expected directory path error, got %v", err)
+	}
+
+	filePath := filepath.Join(tempDir, "notadir.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("failed to create file: %v", err)
+	}
+	fileRel := relPath(t, filePath)
+
+	_, _, _, _, _, err = filesystem.GetFileInfo(fileRel, fileRel)
+	if err == nil || !strings.Contains(err.Error(), "rootDir is not a directory") {
+		t.Fatalf("expected rootDir error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- expand filesystem tests to cover creation, deletion, metadata, and YAML parsing workflows
- add unit tests for command helpers and configuration loading to validate generated content and defaults

## Testing
- go test ./...
- go test ./... -cover

------
https://chatgpt.com/codex/tasks/task_e_68d72b53f98c832eb35bba636d8582a2